### PR TITLE
Obsługa tury poprzez kolor przypisany na początku gry

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -117,12 +117,21 @@ def get_turn():
     return jsonify(current_turn)
 
 @app.route('/end_turn', methods=['POST'])
+
+@app.route('/end_turn', methods=['POST'])
 def end_turn():
-    player_order = ['blue', 'red', 'green', 'yellow']
-    current = current_turn['turn']
-    next_index = (player_order.index(current) + 1) % len(player_order)
-    current_turn['turn'] = player_order[next_index]
-    return jsonify({"next_turn": current_turn['turn']})
+    data = request.json
+    lobby_id = data['lobby_id']
+    rolled = data['dice_value']
+
+    lobby = games[lobby_id]
+    if rolled != 6:
+        current = lobby.player_on_the_move
+        players = lobby.players_connected
+        index = players.index(current)
+        next_index = (index + 1) % len(players)
+        lobby.player_on_the_move = players[next_index]
+    return jsonify({'next_turn': lobby.player_on_the_move})
 
 @app.route('/get_player_color', methods=['GET'])
 def get_player_color():

--- a/api/app.py
+++ b/api/app.py
@@ -110,6 +110,35 @@ def lobby_status():
 def jError():
     return render_template("joining_code_Error.html")
 
+current_turn = {'turn': 'blue'}
+
+@app.route('/get_turn', methods=['GET'])
+def get_turn():
+    return jsonify(current_turn)
+
+@app.route('/end_turn', methods=['POST'])
+def end_turn():
+    player_order = ['blue', 'red', 'green', 'yellow']
+    current = current_turn['turn']
+    next_index = (player_order.index(current) + 1) % len(player_order)
+    current_turn['turn'] = player_order[next_index]
+    return jsonify({"next_turn": current_turn['turn']})
+
+@app.route('/get_player_color', methods=['GET'])
+def get_player_color():
+    player_id = request.args.get('player_id')
+    lobby_id = request.args.get('lobby_id')
+
+    if lobby_id not in games:
+        return jsonify({'error': 'Lobby not found'}), 404
+    lobby = games[lobby_id]
+
+    color = lobby.player_colors.get(player_id)
+    if color is None:
+        return jsonify({'error': 'Player not found'}), 404
+    return jsonify({'color': color})
+
+
 
 if __name__ == "__main__":
     app.run(debug=True)

--- a/api/lobby_handler.py
+++ b/api/lobby_handler.py
@@ -5,16 +5,20 @@ import json
 
 games = {}
 
+# Stała kolejność kolorów
+PLAYER_COLORS = ['blue', 'red', 'green', 'yellow']
+
 def get_games():
     games_dump = json.dumps(games, default=lambda x: x.__dict__)
     return json.loads(games_dump)
-     
+
 class Lobby():
     def __init__(self, host_id):
         self.host_id = host_id
         self.number_of_players_connected = 0
         self.game_in_progress = False
-        self.players_connected = []
+        self.players_connected = []  # Lista ID graczy
+        self.player_colors = {}  # {player_id: color}
         self.player_on_the_move = None
         self.board_status = get_empty_board()
         self.time_created = t.time()
@@ -23,13 +27,11 @@ class Lobby():
     def touch_lobby(func):
         def wrapper(self, *args, **kwargs):
            self.time_since_last_move = 0
-           func(self, *args, **kwargs)
+           return func(self, *args, **kwargs)
         return wrapper
-    
 
 def get_empty_board():
     return "000"
-
 
 def generate_lobby_id():
     pool = string.ascii_lowercase + string.ascii_uppercase + "0123456789"
@@ -38,12 +40,11 @@ def generate_lobby_id():
 
 def create_lobby(host_id):
     id = generate_lobby_id()
-    while id in games: # reroll the id if a game with that id already exists (highly unlikely)
+    while id in games:
         id = generate_lobby_id()
     games[id] = Lobby(host_id=host_id)
     add_player_to_lobby(host_id, id)
     return id
-
 
 def get_lobby_status(lobby_id):
     lobby = games[lobby_id]
@@ -57,9 +58,26 @@ def generate_player_id(length=8):
 def add_player_to_lobby(player_id, lobby_id):
     if lobby_id not in games:
         return -1, f"Lobby {lobby_id} not found"
-    if games[lobby_id].number_of_players_connected > 3:
+    lobby = games[lobby_id]
+
+    if lobby.number_of_players_connected > 3:
         return -2, f"Lobby {lobby_id} is full"
-    if player_id in games[lobby_id].players_connected:
+    if player_id in lobby.players_connected:
         return -3, f"Player {player_id} is already in the lobby {lobby_id}"
-    games[lobby_id].players_connected.append(player_id)
-    games[lobby_id].number_of_players_connected += 1
+
+    # Przydziel kolor
+    used_colors = set(lobby.player_colors.values())
+    available_colors = [c for c in PLAYER_COLORS if c not in used_colors]
+    if not available_colors:
+        return -4, "No available colors"
+
+    assigned_color = available_colors[0]
+    lobby.player_colors[player_id] = assigned_color
+    lobby.players_connected.append(player_id)
+    lobby.number_of_players_connected += 1
+
+    # Jeśli to pierwszy gracz, on zaczyna
+    if lobby.player_on_the_move is None:
+        lobby.player_on_the_move = player_id
+
+    return 0, f"Player {player_id} joined as {assigned_color}"

--- a/client/templates/game.html
+++ b/client/templates/game.html
@@ -32,21 +32,28 @@
     let playerId = localStorage.getItem("player_id");
     let lobbyId = localStorage.getItem("lobby_id");
 
+    let playerColor = null;
+
     fetch(`/get_player_color?player_id=${playerId}&lobby_id=${lobbyId}`)
         .then(response => response.json())
         .then(data => {
             if (data.color) {
                 playerColor = data.color;
+                console.log("Player color: ", playerColor);
+                // Możesz tu aktywować pionki jeśli diceValue już był rzucony
             } else {
                 alert("Nie udało się pobrać koloru gracza.");
-        }
-    });
-    let currentTurn = 'blue';   // nadal pobierane przez /get_turn
-    let playerColor = null;     // ustawiamy dopiero po fetchu
+            }
+        });
+    
+    let currentTurn = 'blue';       
     const canvas = document.getElementById('myCanvas');
     const ctx = canvas.getContext('2d');
     canvas.width = 2048;
     canvas.height = 2048;
+    if (playerColor === currentTurn && diceValue > 0) {
+    activatePlayerPawns(); 
+    }
 
     function metaQuarter(startX, startY, midX, midY, endX, endY, color="black") {
         ctx.beginPath();
@@ -57,6 +64,17 @@
         ctx.fillStyle=color;
         ctx.fill();
     }
+
+    if (pawnIsInBase(pawn)) {
+        if (diceValue === 6) {
+            movePawnOutOfBase(pawn);
+        } else {
+            alert("Musisz wyrzucić 6, by wyjść z bazy");
+        }
+    } else {
+        movePawn(pawn, diceValue);
+    }
+
 
     function buildPart(rows, cols, size, gap, startX, startY) {
         for (let row = 0; row < rows; row++) {

--- a/client/templates/game.html
+++ b/client/templates/game.html
@@ -29,7 +29,20 @@
         {id: 'yellow3', x: 1370, y: 1630, color: '#D4AF37'},
         {id: 'yellow4', x: 1630, y: 1630, color: '#D4AF37'},
     ];
-    
+    let playerId = localStorage.getItem("player_id");
+    let lobbyId = localStorage.getItem("lobby_id");
+
+    fetch(`/get_player_color?player_id=${playerId}&lobby_id=${lobbyId}`)
+        .then(response => response.json())
+        .then(data => {
+            if (data.color) {
+                playerColor = data.color;
+            } else {
+                alert("Nie udało się pobrać koloru gracza.");
+        }
+    });
+    let currentTurn = 'blue';   // nadal pobierane przez /get_turn
+    let playerColor = null;     // ustawiamy dopiero po fetchu
     const canvas = document.getElementById('myCanvas');
     const ctx = canvas.getContext('2d');
     canvas.width = 2048;
@@ -333,10 +346,21 @@ function onPawnClick(event) {
 
             // 🛑 Stop listening after move
             canvas.removeEventListener('click', onPawnClick);
+            fetch('/end_turn', { method: 'POST' });
             break;
         }
     }
 }
+function fetchTurn() {
+    fetch('/get_turn')
+        .then(response => response.json())
+        .then(data => {
+            currentTurn = data.turn;
+            document.getElementById('diceRollButton').disabled = (currentTurn !== playerColor);
+        });
+}
+
+setInterval(fetchTurn, 2000);
 
 
 


### PR DESCRIPTION
Powinno być tak że pierwszy jest niebieski a potem są następni gracze, nie sprawdze tego dokładnie bo musi to być na serwerze z innymi graczami, na live z vs tego nie zrobię. 

lobbyhandler.py: W add_player_to_lobby() przypisywany jest pierwszy dostępny kolor graczowi. Pierwszy dołączony gracz otrzymuje prawo rozpoczęcia gry (player_on_the_move).

app.py: /get_turn – zwraca, czyja jest aktualnie tura, /end_turn – zmienia turę na kolejnego gracza w kolejności, /get_player_color – pozwala frontendowi pobrać kolor przypisany do konkretnego gracza w lobby.